### PR TITLE
Modify Example() method

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -244,3 +244,31 @@ func TestResolvePass(t *testing.T) {
 		t.Errorf("fail to resolve link schema: title should be test: %+v", scm)
 	}
 }
+
+func TestExample(t *testing.T) {
+	hs, err := ParseHschema("./test/example.yml")
+	if err != nil {
+		t.Fatalf("fail to parse resolve: %v", err)
+	}
+	b := jstmpl.NewBuilder()
+	s, err := b.Build(hs)
+	if err != nil {
+		t.Fatalf("fail to build: %+v", err)
+	}
+
+	l := s.Links[0]
+
+	if l.ReqBody() != `{
+  "body": "body example"
+}` {
+		t.Errorf("fail to ReqBody")
+	}
+	if l.ResBody() != `{
+  "body": "body example",
+  "created_at": "2016-05-09T19:45:32Z",
+  "id": 1,
+  "updated_at": "2016-05-10T13:53:08Z"
+}` {
+		t.Errorf("fail to ResBody")
+	}
+}

--- a/test/example.yml
+++ b/test/example.yml
@@ -1,0 +1,58 @@
+href: http://example.com/api/v1
+
+definitions:
+
+  post_id:
+    title: Post ID
+    description: ポストID
+    type: integer
+    example: 1
+    readOnly: true
+    unique: true
+  created_at:
+    title: Created at
+    description: レコード作成日時
+    type: string
+    example: 2016-05-09T19:45:32Z
+    readOnly: true
+    format: date-time
+  updated_at:
+    title: Updated at
+    description: レコード更新日時
+    type: string
+    example: 2016-05-10T13:53:08Z
+    readOnly: true
+    format: date-time
+  post_body:
+    title: Post body
+    description: ポスト本文
+    type: string
+    example: "body example"
+
+  post:
+    title: Post
+    description: ポスト
+    type: object
+    properties:
+      id:
+        $ref: '#/definitions/post_id'
+      created_at:
+        $ref: '#/definitions/created_at'
+      updated_at:
+        $ref: '#/definitions/updated_at'
+      body:
+        $ref: '#/definitions/post_body'
+    required:
+      - body
+
+links:
+
+- title: Create post
+  description: ポストを作成する
+  rel: create
+  href: /posts
+  method: POST
+  schema:
+    $ref: '#/definitions/post'
+  targetSchema:
+    $ref: '#/definitions/post'

--- a/types/array.go
+++ b/types/array.go
@@ -78,10 +78,26 @@ func (o Array) Key() string {
 	return o.key
 }
 
-func (o Array) Example() interface{} {
+func (o Array) ReadOnly() bool {
+	v := o.Schema.Extras["readOnly"]
+	if v == nil {
+		return false
+	}
+	r, ok := v.(bool)
+	if !ok {
+		return false
+	}
+	return r
+}
+
+func (o Array) Example(withoutReadOnly bool) interface{} {
 	e := make([]interface{}, len(o.Items.Schemas))
 	for i, s := range o.Items.Schemas {
-		e[i] = s.Example()
+		e[i] = s.Example(withoutReadOnly)
 	}
 	return e
+}
+
+func (o Array) ExampleString() string {
+	return helpers.Serialize(o.Example(false))
 }

--- a/types/boolean.go
+++ b/types/boolean.go
@@ -73,10 +73,26 @@ func (o Boolean) Key() string {
 	return o.key
 }
 
-func (o Boolean) Example() interface{} {
-	e := o.Schema.Extras["example"]
-	if e != nil {
-		return e
+func (o Boolean) ReadOnly() bool {
+	v := o.Schema.Extras["readOnly"]
+	if v == nil {
+		return false
 	}
-	return false
+	r, ok := v.(bool)
+	if !ok {
+		return false
+	}
+	return r
+}
+
+func (o Boolean) Example(withoutReadOnly bool) interface{} {
+	v := o.Schema.Extras["example"]
+	if v == nil {
+		return false
+	}
+	return v
+}
+
+func (o Boolean) ExampleString() string {
+	return helpers.Serialize(o.Example(false))
 }

--- a/types/boolean_test.go
+++ b/types/boolean_test.go
@@ -8,21 +8,59 @@ import (
 )
 
 func TestNewBoolean(t *testing.T) {
-	s := types.NewBoolean(&types.Context{
-		Raw:         &schema.Schema{},
-		Validations: map[string]bool{},
-	}, &schema.Schema{
-		Title:       "title",
-		Description: "description",
-		Format:      "format",
-	})
-	if s.Title() != "title" {
-		t.Fatalf("Title expected %s but actual %s", "title", s.Title())
+	type Expected struct {
+		Title       string
+		Description string
+		Format      string
+		ReadOnly    bool
 	}
-	if s.Description != "description" {
-		t.Fatalf("Description expected %s but actual %s", "description", s.Description)
+	type Case struct {
+		Schema   *schema.Schema
+		Expected Expected
 	}
-	if s.Format() != "format" {
-		t.Fatalf("Format expected %s but actual %s", "format", s.Format())
+	cases := []Case{
+		Case{
+			&schema.Schema{},
+			Expected{
+				Title:       "",
+				Description: "",
+				Format:      "",
+				ReadOnly:    false,
+			},
+		},
+		Case{
+			&schema.Schema{
+				Title:       "example title",
+				Description: "example description",
+				Format:      "example format",
+				Extras: map[string]interface{}{
+					"readOnly": true,
+				},
+			},
+			Expected{
+				Title:       "example title",
+				Description: "example description",
+				Format:      "example format",
+				ReadOnly:    true,
+			},
+		},
+	}
+	for _, c := range cases {
+		s := types.NewBoolean(&types.Context{
+			Raw:         &schema.Schema{},
+			Validations: map[string]bool{},
+		}, c.Schema)
+		if s.Title() != c.Expected.Title {
+			t.Errorf("Title expected %s but actual %s", c.Expected.Title, s.Title())
+		}
+		if s.Description != c.Expected.Description {
+			t.Errorf("Description expected %s but actual %s", c.Expected.Description, s.Description)
+		}
+		if s.Format() != c.Expected.Format {
+			t.Errorf("Format expected %s but actual %s", c.Expected.Format, s.Format())
+		}
+		if s.ReadOnly() != c.Expected.ReadOnly {
+			t.Errorf("ReadOnly expected %b but actual %b", c.Expected.ReadOnly, s.ReadOnly())
+		}
 	}
 }

--- a/types/integer.go
+++ b/types/integer.go
@@ -81,10 +81,26 @@ func (o Integer) Key() string {
 	return o.key
 }
 
-func (o Integer) Example() interface{} {
-	e := o.Schema.Extras["example"]
-	if e != nil {
-		return e
+func (o Integer) ReadOnly() bool {
+	v := o.Schema.Extras["readOnly"]
+	if v == nil {
+		return false
 	}
-	return 0
+	r, ok := v.(bool)
+	if !ok {
+		return false
+	}
+	return r
+}
+
+func (o Integer) Example(withoutReadOnly bool) interface{} {
+	v := o.Schema.Extras["example"]
+	if v == nil {
+		return 0
+	}
+	return v
+}
+
+func (o Integer) ExampleString() string {
+	return helpers.Serialize(o.Example(false))
 }

--- a/types/integer_test.go
+++ b/types/integer_test.go
@@ -8,21 +8,59 @@ import (
 )
 
 func TestNewInteger(t *testing.T) {
-	s := types.NewInteger(&types.Context{
-		Raw:         &schema.Schema{},
-		Validations: map[string]bool{},
-	}, &schema.Schema{
-		Title:       "title",
-		Description: "description",
-		Format:      "format",
-	})
-	if s.Title() != "title" {
-		t.Fatalf("Title expected %s but actual %s", "title", s.Title())
+	type Expected struct {
+		Title       string
+		Description string
+		Format      string
+		ReadOnly    bool
 	}
-	if s.Description != "description" {
-		t.Fatalf("Description expected %s but actual %s", "description", s.Description)
+	type Case struct {
+		Schema   *schema.Schema
+		Expected Expected
 	}
-	if s.Format() != "format" {
-		t.Fatalf("Format expected %s but actual %s", "format", s.Format())
+	cases := []Case{
+		Case{
+			&schema.Schema{},
+			Expected{
+				Title:       "",
+				Description: "",
+				Format:      "",
+				ReadOnly:    false,
+			},
+		},
+		Case{
+			&schema.Schema{
+				Title:       "example title",
+				Description: "example description",
+				Format:      "example format",
+				Extras: map[string]interface{}{
+					"readOnly": true,
+				},
+			},
+			Expected{
+				Title:       "example title",
+				Description: "example description",
+				Format:      "example format",
+				ReadOnly:    true,
+			},
+		},
+	}
+	for _, c := range cases {
+		s := types.NewInteger(&types.Context{
+			Raw:         &schema.Schema{},
+			Validations: map[string]bool{},
+		}, c.Schema)
+		if s.Title() != c.Expected.Title {
+			t.Errorf("Title expected %s but actual %s", c.Expected.Title, s.Title())
+		}
+		if s.Description != c.Expected.Description {
+			t.Errorf("Description expected %s but actual %s", c.Expected.Description, s.Description)
+		}
+		if s.Format() != c.Expected.Format {
+			t.Errorf("Format expected %s but actual %s", c.Expected.Format, s.Format())
+		}
+		if s.ReadOnly() != c.Expected.ReadOnly {
+			t.Errorf("ReadOnly expected %b but actual %b", c.Expected.ReadOnly, s.ReadOnly())
+		}
 	}
 }

--- a/types/interface.go
+++ b/types/interface.go
@@ -5,7 +5,8 @@ import "github.com/lestrrat/go-jsschema"
 type Schema interface {
 	Title() string
 	Key() string
-	Example() interface{}
+	ReadOnly() bool
+	Example(withoutReadOnly bool) interface{}
 }
 
 type SchemasByKey []Schema

--- a/types/link.go
+++ b/types/link.go
@@ -127,7 +127,7 @@ func (l Link) ReqBody() string {
 		return ""
 	}
 
-	e := l.Schema.Example()
+	e := l.Schema.Example(true)
 	if e == nil {
 		return ""
 	}
@@ -162,7 +162,7 @@ func (l Link) ResBody() string {
 		return ""
 	}
 
-	e := l.TargetSchema.Example()
+	e := l.TargetSchema.Example(false)
 	if e == nil {
 		return ""
 	}

--- a/types/number.go
+++ b/types/number.go
@@ -81,10 +81,26 @@ func (o Number) Key() string {
 	return o.key
 }
 
-func (o Number) Example() interface{} {
-	e := o.Schema.Extras["example"]
-	if e != nil {
-		return e
+func (o Number) ReadOnly() bool {
+	v := o.Schema.Extras["readOnly"]
+	if v == nil {
+		return false
 	}
-	return 0
+	r, ok := v.(bool)
+	if !ok {
+		return false
+	}
+	return r
+}
+
+func (o Number) Example(withoutReadOnly bool) interface{} {
+	v := o.Schema.Extras["example"]
+	if v == nil {
+		return 0
+	}
+	return v
+}
+
+func (o Number) ExampleString() string {
+	return helpers.Serialize(o.Example(false))
 }

--- a/types/number_test.go
+++ b/types/number_test.go
@@ -8,21 +8,59 @@ import (
 )
 
 func TestNewNumber(t *testing.T) {
-	s := types.NewNumber(&types.Context{
-		Raw:         &schema.Schema{},
-		Validations: map[string]bool{},
-	}, &schema.Schema{
-		Title:       "title",
-		Description: "description",
-		Format:      "format",
-	})
-	if s.Title() != "title" {
-		t.Fatalf("Title expected %s but actual %s", "title", s.Title())
+	type Expected struct {
+		Title       string
+		Description string
+		Format      string
+		ReadOnly    bool
 	}
-	if s.Description != "description" {
-		t.Fatalf("Description expected %s but actual %s", "description", s.Description)
+	type Case struct {
+		Schema   *schema.Schema
+		Expected Expected
 	}
-	if s.Format() != "format" {
-		t.Fatalf("Format expected %s but actual %s", "format", s.Format())
+	cases := []Case{
+		Case{
+			&schema.Schema{},
+			Expected{
+				Title:       "",
+				Description: "",
+				Format:      "",
+				ReadOnly:    false,
+			},
+		},
+		Case{
+			&schema.Schema{
+				Title:       "example title",
+				Description: "example description",
+				Format:      "example format",
+				Extras: map[string]interface{}{
+					"readOnly": true,
+				},
+			},
+			Expected{
+				Title:       "example title",
+				Description: "example description",
+				Format:      "example format",
+				ReadOnly:    true,
+			},
+		},
+	}
+	for _, c := range cases {
+		s := types.NewNumber(&types.Context{
+			Raw:         &schema.Schema{},
+			Validations: map[string]bool{},
+		}, c.Schema)
+		if s.Title() != c.Expected.Title {
+			t.Errorf("Title expected %s but actual %s", c.Expected.Title, s.Title())
+		}
+		if s.Description != c.Expected.Description {
+			t.Errorf("Description expected %s but actual %s", c.Expected.Description, s.Description)
+		}
+		if s.Format() != c.Expected.Format {
+			t.Errorf("Format expected %s but actual %s", c.Expected.Format, s.Format())
+		}
+		if s.ReadOnly() != c.Expected.ReadOnly {
+			t.Errorf("ReadOnly expected %b but actual %b", c.Expected.ReadOnly, s.ReadOnly())
+		}
 	}
 }

--- a/types/object.go
+++ b/types/object.go
@@ -74,10 +74,34 @@ func (o Object) Key() string {
 	return o.key
 }
 
-func (o Object) Example() interface{} {
+func (o Object) ReadOnly() bool {
+	v := o.Schema.Extras["readOnly"]
+	if v == nil {
+		return false
+	}
+	r, ok := v.(bool)
+	if !ok {
+		return false
+	}
+	return r
+}
+
+func (o Object) Example(withoutReadOnly bool) interface{} {
 	e := make(map[string]interface{})
+	if withoutReadOnly {
+		for _, s := range o.Properties {
+			if !s.ReadOnly() {
+				e[s.Key()] = s.Example(withoutReadOnly)
+			}
+		}
+		return e
+	}
 	for _, s := range o.Properties {
-		e[s.Key()] = s.Example()
+		e[s.Key()] = s.Example(withoutReadOnly)
 	}
 	return e
+}
+
+func (o Object) ExampleString() string {
+	return helpers.Serialize(o.Example(false))
 }

--- a/types/object_test.go
+++ b/types/object_test.go
@@ -8,21 +8,59 @@ import (
 )
 
 func TestNewObject(t *testing.T) {
-	s := types.NewObject(&types.Context{
-		Raw:         &schema.Schema{},
-		Validations: map[string]bool{},
-	}, &schema.Schema{
-		Title:       "title",
-		Description: "description",
-		Format:      "format",
-	})
-	if s.Title() != "title" {
-		t.Fatalf("Title expected %s but actual %s", "title", s.Title())
+	type Expected struct {
+		Title       string
+		Description string
+		Format      string
+		ReadOnly    bool
 	}
-	if s.Description != "description" {
-		t.Fatalf("Description expected %s but actual %s", "description", s.Description)
+	type Case struct {
+		Schema   *schema.Schema
+		Expected Expected
 	}
-	if s.Format() != "format" {
-		t.Fatalf("Format expected %s but actual %s", "format", s.Format())
+	cases := []Case{
+		Case{
+			&schema.Schema{},
+			Expected{
+				Title:       "",
+				Description: "",
+				Format:      "",
+				ReadOnly:    false,
+			},
+		},
+		Case{
+			&schema.Schema{
+				Title:       "example title",
+				Description: "example description",
+				Format:      "example format",
+				Extras: map[string]interface{}{
+					"readOnly": true,
+				},
+			},
+			Expected{
+				Title:       "example title",
+				Description: "example description",
+				Format:      "example format",
+				ReadOnly:    true,
+			},
+		},
+	}
+	for _, c := range cases {
+		s := types.NewObject(&types.Context{
+			Raw:         &schema.Schema{},
+			Validations: map[string]bool{},
+		}, c.Schema)
+		if s.Title() != c.Expected.Title {
+			t.Errorf("Title expected %s but actual %s", c.Expected.Title, s.Title())
+		}
+		if s.Description != c.Expected.Description {
+			t.Errorf("Description expected %s but actual %s", c.Expected.Description, s.Description)
+		}
+		if s.Format() != c.Expected.Format {
+			t.Errorf("Format expected %s but actual %s", c.Expected.Format, s.Format())
+		}
+		if s.ReadOnly() != c.Expected.ReadOnly {
+			t.Errorf("ReadOnly expected %b but actual %b", c.Expected.ReadOnly, s.ReadOnly())
+		}
 	}
 }

--- a/types/string.go
+++ b/types/string.go
@@ -89,10 +89,26 @@ func (o String) Key() string {
 	return o.key
 }
 
-func (o String) Example() interface{} {
-	e := o.Schema.Extras["example"]
-	if e != nil {
-		return e
+func (o String) ReadOnly() bool {
+	v := o.Schema.Extras["readOnly"]
+	if v == nil {
+		return false
 	}
-	return ""
+	r, ok := v.(bool)
+	if !ok {
+		return false
+	}
+	return r
+}
+
+func (o String) Example(withoutReadOnly bool) interface{} {
+	v := o.Schema.Extras["example"]
+	if v == nil {
+		return ""
+	}
+	return v
+}
+
+func (o String) ExampleString() string {
+	return helpers.Serialize(o.Example(false))
 }

--- a/types/string_test.go
+++ b/types/string_test.go
@@ -8,21 +8,59 @@ import (
 )
 
 func TestNewString(t *testing.T) {
-	s := types.NewString(&types.Context{
-		Raw:         &schema.Schema{},
-		Validations: map[string]bool{},
-	}, &schema.Schema{
-		Title:       "title",
-		Description: "description",
-		Format:      "format",
-	})
-	if s.Title() != "title" {
-		t.Fatalf("Title expected %s but actual %s", "title", s.Title())
+	type Expected struct {
+		Title       string
+		Description string
+		Format      string
+		ReadOnly    bool
 	}
-	if s.Description != "description" {
-		t.Fatalf("Description expected %s but actual %s", "description", s.Description)
+	type Case struct {
+		Schema   *schema.Schema
+		Expected Expected
 	}
-	if s.Format() != "format" {
-		t.Fatalf("Format expected %s but actual %s", "format", s.Format())
+	cases := []Case{
+		Case{
+			&schema.Schema{},
+			Expected{
+				Title:       "",
+				Description: "",
+				Format:      "",
+				ReadOnly:    false,
+			},
+		},
+		Case{
+			&schema.Schema{
+				Title:       "example title",
+				Description: "example description",
+				Format:      "example format",
+				Extras: map[string]interface{}{
+					"readOnly": true,
+				},
+			},
+			Expected{
+				Title:       "example title",
+				Description: "example description",
+				Format:      "example format",
+				ReadOnly:    true,
+			},
+		},
+	}
+	for _, c := range cases {
+		s := types.NewString(&types.Context{
+			Raw:         &schema.Schema{},
+			Validations: map[string]bool{},
+		}, c.Schema)
+		if s.Title() != c.Expected.Title {
+			t.Errorf("Title expected %s but actual %s", c.Expected.Title, s.Title())
+		}
+		if s.Description != c.Expected.Description {
+			t.Errorf("Description expected %s but actual %s", c.Expected.Description, s.Description)
+		}
+		if s.Format() != c.Expected.Format {
+			t.Errorf("Format expected %s but actual %s", c.Expected.Format, s.Format())
+		}
+		if s.ReadOnly() != c.Expected.ReadOnly {
+			t.Errorf("ReadOnly expected %b but actual %b", c.Expected.ReadOnly, s.ReadOnly())
+		}
 	}
 }

--- a/types/undefined.go
+++ b/types/undefined.go
@@ -57,10 +57,26 @@ func (o Undefined) Key() string {
 	return o.key
 }
 
-func (o Undefined) Example() interface{} {
-	e := o.Schema.Extras["example"]
-	if e != nil {
-		return e
+func (o Undefined) ReadOnly() bool {
+	v := o.Schema.Extras["readOnly"]
+	if v == nil {
+		return false
 	}
-	return ""
+	r, ok := v.(bool)
+	if !ok {
+		return false
+	}
+	return r
+}
+
+func (o Undefined) Example(withoutReadOnly bool) interface{} {
+	v := o.Schema.Extras["example"]
+	if v == nil {
+		return ""
+	}
+	return v
+}
+
+func (o Undefined) ExampleString() string {
+	return helpers.Serialize(o.Example(false))
 }


### PR DESCRIPTION
Make `Example()` method possible to ignore `readOnly` properties in Object.