### PR TITLE
Remove setting for delimiter

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -15,7 +15,7 @@ func NewGenerator() *Generator {
 }
 
 func (g *Generator) Process(out io.Writer, model *types.Root, tmpl []byte) error {
-	t := template.Must(template.New("").Delims("/*", "*/").Funcs(map[string]interface{}{
+	t := template.Must(template.New("").Funcs(map[string]interface{}{
 		"notLast":            helpers.NotLast,
 		"joinTypes":          helpers.JoinTypes,
 		"serialize":          helpers.Serialize,


### PR DESCRIPTION
I want to use default delimiter `{{...}}` for hilighting in text editor.