### PR TITLE
Support numeric strings in the helper for strings

### DIFF
--- a/helpers/strings.go
+++ b/helpers/strings.go
@@ -19,6 +19,10 @@ func isLower(c rune) bool {
 	return 'a' <= c && 'z' >= c
 }
 
+func isNumeric(c rune) bool {
+	return '0' <= c && '9' >= c
+}
+
 func LowerSnakeCase(s string) string {
 	return strings.ToLower(SnakeCase(s))
 }
@@ -43,7 +47,7 @@ func Chop(s string, d rune) string {
 				}
 			}
 			b.WriteRune(c)
-		case !isAlphabetical(c):
+		case !(isAlphabetical(c) || isNumeric(c)):
 			b.WriteRune(d)
 		default:
 			b.WriteRune(c)
@@ -69,7 +73,7 @@ func CamelCase(s string, fn convert) string {
 	for i := 0; i < len(s); i++ {
 		c := rune(s[i])
 		switch {
-		case !isAlphabetical(c):
+		case !(isAlphabetical(c) || isNumeric(c)):
 			apply = true
 		case first:
 			first = false

--- a/helpers/strings_test.go
+++ b/helpers/strings_test.go
@@ -54,8 +54,13 @@ func TestLowerSnakeCase(t *testing.T) {
 			Message:  "upper camel case",
 		},
 		Case{
-			Input:    "_mixed veryUgly_Case_",
-			Expected: "_mixed_very_ugly_case_",
+			Input:    "numeric 00 string",
+			Expected: "numeric_00_string",
+			Message:  "numeric string",
+		},
+		Case{
+			Input:    "_mixed veryUgly_00_Case_",
+			Expected: "_mixed_very_ugly_00_case_",
 			Message:  "mixed very ugly case",
 		},
 	}
@@ -115,8 +120,13 @@ func TestUpperSnakeCase(t *testing.T) {
 			Message:  "upper camel case",
 		},
 		Case{
-			Input:    "_mixed veryUgly_Case_",
-			Expected: "_MIXED_VERY_UGLY_CASE_",
+			Input:    "numeric 00 string",
+			Expected: "NUMERIC_00_STRING",
+			Message:  "numeric string",
+		},
+		Case{
+			Input:    "_mixed veryUgly_00_Case_",
+			Expected: "_MIXED_VERY_UGLY_00_CASE_",
 			Message:  "mixed very ugly case",
 		},
 	}
@@ -176,8 +186,13 @@ func TestLowerCamelCase(t *testing.T) {
 			Message:  "upper camel case",
 		},
 		Case{
-			Input:    "_mixed veryUgly_Case_",
-			Expected: "mixedVeryUglyCase",
+			Input:    "numeric 00 string",
+			Expected: "numeric00String",
+			Message:  "numeric string",
+		},
+		Case{
+			Input:    "_mixed veryUgly_00_Case_",
+			Expected: "mixedVeryUgly00Case",
 			Message:  "mixed very ugly case",
 		},
 	}
@@ -237,8 +252,13 @@ func TestUpperCamelCase(t *testing.T) {
 			Message:  "upper camel case",
 		},
 		Case{
-			Input:    "_mixed veryUgly_Case_",
-			Expected: "MixedVeryUglyCase",
+			Input:    "numeric 00 string",
+			Expected: "Numeric00String",
+			Message:  "numeric string",
+		},
+		Case{
+			Input:    "_mixed veryUgly_00_Case_",
+			Expected: "MixedVeryUgly00Case",
 			Message:  "mixed very ugly case",
 		},
 	}


### PR DESCRIPTION
In current version, numeric strings are ignored in UpperCamelCase, and so on.
This p-r fixes it.